### PR TITLE
Dont duplicate message for each line

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -92,15 +92,12 @@ export class PapertrailTransport extends Transport {
   }
 
   sendMessage(level: any, message: string, callback: any) {
-    let lines;
+    let lines = [''];
     let msg = '';
-    let gap = '';
 
     // Only split if we actually have a message
     if (message) {
       lines = message.split('\n');
-    } else {
-      lines = [''];
     }
 
     // If the incoming message has multiple lines, break them and format each
@@ -111,10 +108,6 @@ export class PapertrailTransport extends Transport {
         break;
       }
 
-      if (i === 1) {
-        gap = '    ';
-      }
-
       // Needs a valid severity - default to "notice" if the map failed.
       const severity = this.options.levels[level] || 5;
       msg +=
@@ -123,7 +116,7 @@ export class PapertrailTransport extends Transport {
           host: this.options.hostname,
           appName: this.options.program,
           date: new Date(),
-          message,
+          message: lines[i],
         }) + '\r\n';
     }
 


### PR DESCRIPTION
Multiline messages is duplicated, for each line, the same message is printed.

A message like 
```js 
'This\nis\na\ntest'
``` 
will be printed 4 times, see papertrail output:

<img width="102" alt="Skærmbillede 2020-09-01 kl  16 24 37" src="https://user-images.githubusercontent.com/38133570/91863692-aca15280-ec6f-11ea-9dfe-3cdb2edeff58.png">
